### PR TITLE
Move 'backward' stacktrace stuff from '3rdparty/eventuals' here

### DIFF
--- a/BUILD.backward-stacktrace.bazel
+++ b/BUILD.backward-stacktrace.bazel
@@ -1,0 +1,13 @@
+# Use this library in order to get more consistent
+# stack trace on any failure.
+cc_library(
+    name = "backward-stacktrace",
+    srcs = ["backward-stacktrace.cc"],
+    hdrs = ["backward-stacktrace.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_backward_cpp//:backward",
+        "@com_github_google_googletest//:gtest",
+    ],
+    alwayslink = True,
+)

--- a/backward-stacktrace.cc
+++ b/backward-stacktrace.cc
@@ -1,0 +1,10 @@
+#include "backward-stacktrace.h"
+
+#include "gtest/gtest.h"
+
+// For setting up gtest environment in order to
+// provide our own stack traces for both LOG(FATAL)
+// and an arbitrary signal being raised.
+static testing::Environment* const kBackwardEnv =
+    testing::AddGlobalTestEnvironment(
+        new backward_stacktrace::BackwardStackTrace{});

--- a/backward-stacktrace.h
+++ b/backward-stacktrace.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "backward.hpp"
+#include "gtest/gtest.h"
+
+namespace backward_stacktrace {
+
+// Do set-up and tear-down at the test program level.
+// When RUN_ALL_TESTS() is called, it first calls the
+// SetUp() method of the environment object, then runs
+// the tests if there was no fatal failures, and finally
+// calls TearDown() of the environment object. If there
+// was any failure - a simple helper class
+// `backward::SignalHandling` will register this for us
+// and print out consistent stacktrace.
+// (check_line_length skip)
+// https://github.com/YOU-i-Labs/googletest/blob/master/googletest/docs/V1_7_AdvancedGuide.md#global-set-up-and-tear-down
+class BackwardStackTrace : public ::testing::Environment {
+ private:
+  // A simple helper class that registers for you the most
+  // common signals and other callbacks to segfault,
+  // hardware exception, un-handled exception etc.
+  backward::SignalHandling sh;
+};
+
+} // namespace backward_stacktrace

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -16,7 +16,7 @@ filegroup(
 def deps(repo_mapping = {}):
     rules_foreign_cc_dependencies()
 
-    # Grab the latest version of all repos needed.
+    # Get the latest rules for building C/C++ projects.
     maybe(
         http_archive,
         name = "rules_foreign_cc",
@@ -26,6 +26,8 @@ def deps(repo_mapping = {}):
         repo_mapping = repo_mapping,
     )
 
+    # Get the latest texinfo version. 'binutils' doesn't compile
+    # without this binary.
     maybe(
         http_archive,
         name = "com_github_texinfo",
@@ -35,6 +37,7 @@ def deps(repo_mapping = {}):
         strip_prefix = "texinfo-6.8",
     )
 
+    # Get the latest binutils version to read the debug info.
     maybe(
         http_archive,
         name = "com_github_binutils",
@@ -44,6 +47,9 @@ def deps(repo_mapping = {}):
         strip_prefix = "binutils-2.38",
     )
 
+    # Get the latest libunwind version to unwind the stack. (There is no need
+    # in this library on macOS, because on macOS clang provides a libunwind API
+    # compatible library as part of its environment).
     maybe(
         http_archive,
         name = "com_github_libunwind",
@@ -53,6 +59,7 @@ def deps(repo_mapping = {}):
         strip_prefix = "libunwind-1.6.2",
     )
 
+    # Get the latest lzma version.
     maybe(
         new_git_repository,
         name = "com_github_lzma",
@@ -62,12 +69,13 @@ def deps(repo_mapping = {}):
         shallow_since = "1385587354 -0500",
     )
 
+    # Get the latest gtest version.
     maybe(
         http_archive,
         name = "com_github_google_googletest",
-        url = "https://github.com/google/googletest/archive/release-1.11.0.tar.gz",
-        sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
-        strip_prefix = "googletest-release-1.11.0",
+        url = "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz",
+        sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
+        strip_prefix = "googletest-release-1.12.1",
         repo_mapping = repo_mapping,
     )
 

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -58,7 +58,17 @@ def deps(repo_mapping = {}):
         name = "com_github_lzma",
         remote = "https://github.com/kobolabs/liblzma.git",
         build_file_content = _ALL_CONTENT,
-        branch = "master",
+        commit = "87b7682ce4b1c849504e2b3641cebaad62aaef87",
+        shallow_since = "1385587354 -0500",
+    )
+
+    maybe(
+        http_archive,
+        name = "com_github_google_googletest",
+        url = "https://github.com/google/googletest/archive/release-1.11.0.tar.gz",
+        sha256 = "b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5",
+        strip_prefix = "googletest-release-1.11.0",
+        repo_mapping = repo_mapping,
     )
 
     maybe(

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -9,7 +9,7 @@
 # instructions at https://github.com/3rdparty/bazel-rules-backward-cpp.
 ########################################################################
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def repos(external = True, repo_mapping = {}):
@@ -20,4 +20,13 @@ def repos(external = True, repo_mapping = {}):
         commit = "6a88dc2d7a3ab98514997a4dfaf949f33da72bed",
         shallow_since = "1657095319 +0300",
         repo_mapping = repo_mapping,
+    )
+
+    maybe(
+        new_git_repository,
+        name = "com_github_3rdparty_bazel_rules_backward_cpp_stacktrace",
+        remote = "https://github.com/3rdparty/bazel-rules-backward-cpp",
+        build_file = "@com_github_3rdparty_bazel_rules_backward_cpp//:BUILD.backward-stacktrace.bazel",
+        commit = "87b7682ce4b1c849504e2b3641cebaad62aaef87",
+        shallow_since = "1658064115 +0300",
     )

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -17,8 +17,8 @@ def repos(external = True, repo_mapping = {}):
         git_repository,
         name = "com_github_3rdparty_bazel_rules_backward_cpp",
         remote = "https://github.com/3rdparty/bazel-rules-backward-cpp",
-        commit = "6a88dc2d7a3ab98514997a4dfaf949f33da72bed",
-        shallow_since = "1657095319 +0300",
+        commit = "c8eecf571b6eb4c06c0b21b22c3fd66a4159aea8",
+        shallow_since = "1658071441 +0300",
         repo_mapping = repo_mapping,
     )
 
@@ -27,6 +27,6 @@ def repos(external = True, repo_mapping = {}):
         name = "com_github_3rdparty_bazel_rules_backward_cpp_stacktrace",
         remote = "https://github.com/3rdparty/bazel-rules-backward-cpp",
         build_file = "@com_github_3rdparty_bazel_rules_backward_cpp//:BUILD.backward-stacktrace.bazel",
-        commit = "87b7682ce4b1c849504e2b3641cebaad62aaef87",
-        shallow_since = "1658064115 +0300",
+        commit = "c8eecf571b6eb4c06c0b21b22c3fd66a4159aea8",
+        shallow_since = "1658071441 +0300",
     )

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -17,8 +17,8 @@ def repos(external = True, repo_mapping = {}):
         git_repository,
         name = "com_github_3rdparty_bazel_rules_backward_cpp",
         remote = "https://github.com/3rdparty/bazel-rules-backward-cpp",
-        commit = "c8eecf571b6eb4c06c0b21b22c3fd66a4159aea8",
-        shallow_since = "1658071441 +0300",
+        commit = "69449957a41619e9b8b8be2e9bfaca2ac0642760",
+        shallow_since = "1658132015 +0300",
         repo_mapping = repo_mapping,
     )
 
@@ -27,6 +27,6 @@ def repos(external = True, repo_mapping = {}):
         name = "com_github_3rdparty_bazel_rules_backward_cpp_stacktrace",
         remote = "https://github.com/3rdparty/bazel-rules-backward-cpp",
         build_file = "@com_github_3rdparty_bazel_rules_backward_cpp//:BUILD.backward-stacktrace.bazel",
-        commit = "c8eecf571b6eb4c06c0b21b22c3fd66a4159aea8",
-        shallow_since = "1658071441 +0300",
+        commit = "69449957a41619e9b8b8be2e9bfaca2ac0642760",
+        shallow_since = "1658132015 +0300",
     )


### PR DESCRIPTION
Since 'backward-stacktrace.cc|.h' are completely unrelated to eventuals,
so it makes sense to keep them separate. Thus it would be easy to use
that in '3rdparty/eventuals' and 'reboot-dev/respect' repos.